### PR TITLE
Fix Reddit handler: call Reddit.fix_link and respond with fixed_link

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -48,9 +48,9 @@ BOT.message(contains: Twitter::REGEX) do |event|
 end
 
 BOT.message(contains: Reddit::REGEX) do |event|
-  fixed_link = TikTok.fix_link(event)
+  fixed_link = Reddit.fix_link(event)
   LOGGER.info(service: 'reddit', user: event.message.author.display_name, fixed_link: fixed_link)
-  response = event.respond(new_link, false, nil, nil, nil, event.message)
+  response = event.respond(fixed_link, false, nil, nil, nil, event.message)
   event.message.suppress_embeds
 
   BOT.add_await!(Discordrb::Events::MessageDeleteEvent, timeout: 30) do |delete_event|


### PR DESCRIPTION
## Summary
This PR fixes a bug in the Reddit message handler in `main.rb` that incorrectly called `TikTok.fix_link(event)` and responded with an undefined `new_link` variable. The handler now calls `Reddit.fix_link(event)` and responds with the `fixed_link` variable so Reddit links are transformed to the expected `rxddit` domain.

## Changes
- **Files changed**
  - `main.rb`
- **Edits**
  - Replace `fixed_link = TikTok.fix_link(event)` with `fixed_link = Reddit.fix_link(event)`.
  - Replace `event.respond(new_link, ...)` with `event.respond(fixed_link, ...)`.
